### PR TITLE
[DEV-82546][DEV-85126] Updates for JDK 11/Scala 2.12/Spark 2.4

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,9 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+    <!-- Repository on AMAZON S3 -->
+    <extension>
+        <groupId>org.springframework.build</groupId>
+        <artifactId>aws-maven</artifactId>
+        <version>5.0.0.RELEASE</version>
+    </extension>
+</extensions>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: java
+
+jdk:
+- openjdk11
+
+cache:
+  directories:
+  - "$HOME/.m2/repository/"
+
+notifications:
+  slack:
+    secure: pFdspUKOhXTTS5EI4IwRWixkzw5vf/dz+CRKNRhylPjzhAqdTI8JIZ5snqwjocZyux63DvT2e41GaKGO3xVsNhp5cvoP2OQef3S2FQNJceAvYHpQbuLiwdA+ndoKs8lYU6wI2uUsHSE0CGfT8ia3B6heH8YxYdAMtQsGl3YO0gm5xg4MFYTZYPxSw2uJQYpr5qDIul+QjmiWR7iN2zv6RN5i1Di6fy/oRE4hFh8vlu5X/9Vmp91S376bG9VVCH0OrT1QSqOmcfTC1TaU04z6EugJsAHuVK/3GOSdoRx9ODYrZyDTFFYu69m0F2hjehejDYSRaBQ+5funnrU7Z81mCVz9PO8Y2EzgSLteULh6Jz10HloflzAs14AwUuJ6XxZd+nENIeVFvJUrv6fFdN9vPRKvDmSouNTgdUPCKKEjc9Mx6ZAN70aQSly3rP2yRJ+Y3AAW9jePgsAmgeiR2onlm+BsRFbskhjA72xL6xUNzHZsqjsAe2vUg7BGOreGZ2LkVcgOgqu+FMGdPFnR21vlaJyx7+0VT0/5czEvxCbaTL2gm1OvP1hR9MrVPHJ5a6WMIFOPbO7VVpLTfHX3gpjhrigb5fF0VE6Hh3V7gg0OYxXj5zVoDHBdUmx+jJlmQZPvzBKUfMwxDvqj6slDsT94A7nqWOEM3Ou93x7qi3dj4oc=
+
+script: mvn verify -DskipITs -B --settings settings.xml
+after_success: mvn jar:jar jar:test-jar source:jar source:test-jar deploy:deploy --settings
+  settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,48 @@
         <tag>HEAD</tag>
     </scm>
 
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>Central Repository - Google Mirror</name>
+            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
+        </repository>
+        <repository>
+            <id>mapr-releases</id>
+            <url>https://repository.mapr.com/maven/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
+        <repository>
+            <id>opsd-snapshot</id>
+            <url>s3://repository.opsd.tesm.com/snapshot</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+                <updatePolicy>always</updatePolicy>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>opsd-release</id>
+            <url>s3://repository.opsd.tesm.com/release</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <distributionManagement>
         <repository>
             <id>dexda-release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.groupon.dse</groupId>
-    <artifactId>spark-metrics</artifactId>
+    <artifactId>spark-metrics_2.12</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.1-dexda-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A library to expose more of Apache Spark's metrics system</description>
@@ -41,42 +41,47 @@
     </scm>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>dexda-release</id>
+            <name>Dexda Release Repository</name>
+            <url>s3://repository.opsd.tesm.com/release</url>
         </repository>
+        <snapshotRepository>
+            <id>dexda-snapshot</id>
+            <name>Dexda Snapshot Repository</name>
+            <url>s3://repository.opsd.tesm.com/snapshot</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <parent>
         <groupId>org.basepom</groupId>
         <artifactId>basepom-oss</artifactId>
-        <version>18</version>
+        <version>40</version>
     </parent>
 
     <properties>
         <!-- Dependencies -->
-        <dropwizard.version>3.1.2</dropwizard.version>
-        <scala.compat.version>2.11</scala.compat.version>
-        <spark.version>2.0.1</spark.version>
-        <jetty.version>8.1.14.v20131031</jetty.version>
-        <scalatest.version>2.2.6</scalatest.version>
+        <dropwizard.version>3.2.6</dropwizard.version>
+        <scala.compat.version>2.12</scala.compat.version>
+        <spark.version>2.4.8-mapr-710-dexda-0.0.11-SNAPSHOT</spark.version>
+        <jetty.version>9.4.40.v20210413</jetty.version>
+        <scalatest.version>3.2.10</scalatest.version>
 
         <!-- Plugins -->
         <dep.plugin.scalatest-maven-plugin.version>1.0</dep.plugin.scalatest-maven-plugin.version>
         <dep.plugin.scalastyle-maven-plugin.version>0.6.0</dep.plugin.scalastyle-maven-plugin.version>
 
         <!-- Basepom Overrides -->
-        <dep.scala.version>2.11.8</dep.scala.version>
+        <dep.scala.version>2.12.10</dep.scala.version>
         <dep.plugin.scala.version>3.2.2</dep.plugin.scala.version>
+        <scala-maven-plugin.version>4.3.0</scala-maven-plugin.version>
+
         <basepom.release.push-changes>true</basepom.release.push-changes>
         <basepom.check.fail-duplicate-finder>false</basepom.check.fail-duplicate-finder>
         <basepom.check.fail-findbugs>false</basepom.check.fail-findbugs>
         <basepom.oss.skip-scala-doc>false</basepom.oss.skip-scala-doc>
-        <project.build.targetJdk>1.8</project.build.targetJdk>
+        <project.build.systemJdk>11</project.build.systemJdk>
+        <project.build.targetJdk>11</project.build.targetJdk>
     </properties>
 
     <build>
@@ -84,6 +89,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
+                <version>${scala-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>scala-compile-first</id>
@@ -196,6 +202,13 @@
                         <releaseProfiles>basepom.oss-release</releaseProfiles>
                     </configuration>
                 </plugin>
+                <plugin>
+                  <groupId>com.github.spotbugs</groupId>
+                  <artifactId>spotbugs-maven-plugin</artifactId>
+                  <configuration>
+                    <skip>true</skip>
+                  </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
@@ -215,14 +228,14 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.11</artifactId>
+            <artifactId>spark-core_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-streaming_2.11</artifactId>
+            <artifactId>spark-streaming_${scala.compat.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
 
@@ -254,7 +267,7 @@
 
         <dependency>
             <groupId>org.scalatest</groupId>
-            <artifactId>scalatest_2.11</artifactId>
+            <artifactId>scalatest_${scala.compat.version}</artifactId>
             <scope>test</scope>
             <version>${scalatest.version}</version>
             <exclusions>
@@ -264,6 +277,43 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest-shouldmatchers_${scala.compat.version}</artifactId>
+            <scope>test</scope>
+            <version>${scalatest.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest-compatible</artifactId>
+            <scope>test</scope>
+            <version>${scalatest.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest-flatspec_${scala.compat.version}</artifactId>
+            <scope>test</scope>
+            <version>${scalatest.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest-core_${scala.compat.version}</artifactId>
+            <scope>test</scope>
+            <version>${scalatest.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatest</groupId>
+            <artifactId>scalatest-matchers-core_${scala.compat.version}</artifactId>
+            <scope>test</scope>
+            <version>${scalatest.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scalactic</groupId>
+            <artifactId>scalactic_${scala.compat.version}</artifactId>
+            <scope>test</scope>
+            <version>${scalatest.version}</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,14 @@
+<settings>
+  <servers>
+    <server>
+      <id>dexda-snapshot</id>
+      <username>${env.AWS_ACCESS_KEY_ID}</username>
+      <password>${env.AWS_SECRET_ACCESS_KEY}</password>
+    </server>
+    <server>
+      <id>dexda-release</id>
+      <username>${env.AWS_ACCESS_KEY_ID}</username>
+      <password>${env.AWS_SECRET_ACCESS_KEY}</password>
+    </server>
+  </servers>
+</settings>

--- a/src/test/scala/org/apache/spark/groupon/metrics/MetricsReceiverTest.scala
+++ b/src/test/scala/org/apache/spark/groupon/metrics/MetricsReceiverTest.scala
@@ -35,9 +35,11 @@ package org.apache.spark.groupon.metrics
 import com.codahale.metrics._
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{Matchers, BeforeAndAfter, FlatSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MetricsReceiverTest extends FlatSpec with Matchers with BeforeAndAfter with Eventually {
+class MetricsReceiverTest extends AnyFlatSpec with Matchers with BeforeAndAfter with Eventually {
   private val master = "local[2]"
   private val appName = "test"
   private val sparkConf = new SparkConf().setAppName(appName).setMaster(master)

--- a/src/test/scala/org/apache/spark/groupon/metrics/SparkMetricTest.scala
+++ b/src/test/scala/org/apache/spark/groupon/metrics/SparkMetricTest.scala
@@ -33,15 +33,16 @@
 package org.apache.spark.groupon.metrics
 
 import java.util.concurrent.TimeUnit
-
-import org.apache.spark.groupon.metrics.util.{TestMetricsRpcEndpoint, SparkContextSetup}
+import org.apache.spark.groupon.metrics.util.{SparkContextSetup, TestMetricsRpcEndpoint}
 import org.apache.spark.rpc.RpcEndpointRef
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{Matchers, BeforeAndAfter, FlatSpec}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Random
 
-class SparkMetricTest extends FlatSpec with Matchers with BeforeAndAfter with Eventually with SparkContextSetup {
+class SparkMetricTest extends AnyFlatSpec with Matchers with BeforeAndAfter with Eventually with SparkContextSetup {
   var metricsEndpoint: TestMetricsRpcEndpoint = _
   var metricsEndpointRef: RpcEndpointRef = _
 

--- a/src/test/scala/org/apache/spark/groupon/metrics/UserMetricsSystemTest.scala
+++ b/src/test/scala/org/apache/spark/groupon/metrics/UserMetricsSystemTest.scala
@@ -33,9 +33,10 @@
 package org.apache.spark.groupon.metrics
 
 import org.apache.spark.groupon.metrics.util.SparkContextSetup
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class UserMetricsSystemTest extends FlatSpec with Matchers with SparkContextSetup {
+class UserMetricsSystemTest extends AnyFlatSpec with Matchers with SparkContextSetup {
   override def beforeAll(): Unit = {
     super.beforeAll()
     UserMetricsSystem.initialize(sc)


### PR DESCRIPTION
2.0.1-SNAPSHOT:
- update versions for jdk 11, scala 2.12, spark 2.4.x
- update test frameworks, and tests
- update org.basepom parent pom to 40, disable spotbugs analysis
- build configs for Travis CI, Dexda private artifact repositories