### PR TITLE
(2.0.1-dexda-2.0.0-SNAPSHOT): Update dropwizard-metrics to 4.1.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.groupon.dse</groupId>
     <artifactId>spark-metrics_2.12</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.1-dexda</version>
+    <version>2.0.1-dexda-2.0.0-SNAPSHOT</version>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A library to expose more of Apache Spark's metrics system</description>
@@ -103,7 +103,7 @@
 
     <properties>
         <!-- Dependencies -->
-        <dropwizard.version>3.2.6</dropwizard.version>
+        <dropwizard-metrics.version>4.1.1</dropwizard-metrics.version>
         <scala.compat.version>2.12</scala.compat.version>
         <spark.version>2.4.8-mapr-710-dexda-0.0.11</spark.version>
         <jetty.version>9.4.40.v20210413</jetty.version>
@@ -259,7 +259,56 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>${dropwizard.version}</version>
+            <version>${dropwizard-metrics.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jvm</artifactId>
+            <version>${dropwizard-metrics.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-graphite</artifactId>
+            <version>${dropwizard-metrics.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-json</artifactId>
+            <version>${dropwizard-metrics.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-jmx</artifactId>
+            <version>${dropwizard-metrics.version}</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>

--- a/src/main/scala/org/apache/spark/groupon/metrics/SparkMetric.scala
+++ b/src/main/scala/org/apache/spark/groupon/metrics/SparkMetric.scala
@@ -32,10 +32,11 @@
 
 package org.apache.spark.groupon.metrics
 
+
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
-
-import com.codahale.metrics.{Clock, Reservoir, Metric}
+import com.codahale.metrics.jvm.CpuTimeClock
+import com.codahale.metrics.{Clock, Metric, Reservoir}
 import com.codahale.metrics.{ExponentiallyDecayingReservoir, SlidingTimeWindowReservoir, SlidingWindowReservoir, UniformReservoir}
 import org.apache.spark.rpc.RpcEndpointRef
 
@@ -214,7 +215,7 @@ class SparkTimer private[metrics] (
 
 object ClockClass {
   val UserTime = classOf[Clock.UserTimeClock]
-  val CpuTime = classOf[Clock.CpuTimeClock]
+  val CpuTime = classOf[CpuTimeClock]
 }
 
 object ReservoirClass {


### PR DESCRIPTION
CpuTimeClock has moved to metrics-jmx in 4.1.x.
